### PR TITLE
Remove "node_modules" entry from .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-node_modules
 dist


### PR DESCRIPTION
There is no need to write `node_modules` line to the `.eslintignore` file since that directory is already implicitly ignoring — check out the [ESLint documentation](https://eslint.org/docs/user-guide/configuring/ignoring-code):

> In addition to any patterns in the .eslintignore file, ESLint always follows a couple of implicit ignore rules even if the --no-ignore flag is passed. The implicit rules are as follows:
− node_modules/ is ignored.
− dot-files (except for .eslintrc.*), as well as dot-folders and their contents, are ignored.